### PR TITLE
Replace slash "/" with "\" in s3 key name

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,14 @@ module.exports = {
 			return next();
 		}
 
-		var key = req.prerender.url;
+		var key = req.prerender.url.replace(/\//g, '\\');
 
 		if (process.env.S3_PREFIX_KEY) {
 			key = process.env.S3_PREFIX_KEY + '/' + key;
 		}
 
 		s3.getObject({
-				Key: key
+			Key: key
 		}, function (err, result) {
 
 			if (!err && result) {
@@ -30,8 +30,8 @@ module.exports = {
 			return next();
 		}
 
-		var key = req.prerender.url;
-		
+		var key = req.prerender.url.replace(/\//g, '\\');
+
 		if (process.env.S3_PREFIX_KEY) {
 			key = process.env.S3_PREFIX_KEY + '/' + key;
 		}


### PR DESCRIPTION
AWS S3 treats "/" as folder path breaks. So what happens is, the file uploaded, gets a path like 

https -> { blank } -> domain -> rest..

this will replace the "/", so the new filename will be like:

https:\\domain\rest..

Browsers do treat the `/` as `\` only.